### PR TITLE
Add exceptions for assembly Episerver.Forms.UI

### DIFF
--- a/src/ScheduledJobsCleaner/InitializationModule.cs
+++ b/src/ScheduledJobsCleaner/InitializationModule.cs
@@ -49,7 +49,7 @@ namespace ScheduledJobsCleaner
                     Name = job.Name,
                     AssemblyName = job.AssemblyName
                 })
-                .Where(x => !x.FromCode)
+                .Where(x => !x.FromCode && !x.AssemblyName.Contains("Forms.UI"))
                 .ToList();
 
             return ghostJobs;


### PR DESCRIPTION
Since package contains scheduled job that has disabled its own plugInDescriptor. Solves #2 

An alternative is to extend the `ScheduledJob`-model to include `job.TypeName` so that one can add an exception for the full TypeName `EPiServer.Forms.EditView.JobScheduler.UpdateMissingValueOfRetentionPolicyJob`.